### PR TITLE
Replace name lane with layers in TimelaneView.tsx

### DIFF
--- a/src/frontend/views/TimelineView/TimelaneView.tsx
+++ b/src/frontend/views/TimelineView/TimelaneView.tsx
@@ -62,7 +62,7 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
     public refs: {
         scaleList: DropDown
         keyframeView: KeyframeEditor
-        timelineLanes: HTMLUListElement
+        timelineLayers: HTMLUListElement
         timelineLabels: HTMLDivElement
     }
 
@@ -82,14 +82,14 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
 
     public componentDidUpdate()
     {
-        this.refs.timelineLabels.scrollTop = this.refs.timelineLanes.scrollTop = this.state.timelineScrollTop
+        this.refs.timelineLabels.scrollTop = this.refs.timelineLayers.scrollTop = this.state.timelineScrollTop
     }
 
     private _syncCursorHeight = () =>
     {
-        const {timelineLanes, keyframeView} = this.refs
+        const {timelineLayers, keyframeView} = this.refs
 
-        const timelineHeight = timelineLanes.getBoundingClientRect().height
+        const timelineHeight = timelineLayers.getBoundingClientRect().height
         const keyFrameViewHeight = ReactDOM.findDOMNode(keyframeView).getBoundingClientRect().height
 
         this.setState({
@@ -142,9 +142,9 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
 
     private handleKeyframeEditorScroll = (dx: number, dy: number) =>
     {
-        const {timelineLanes} = this.refs
-        timelineLanes.scrollLeft += dx
-        this.setState({timelineScrollLeft: timelineLanes.scrollLeft})
+        const {timelineLayers} = this.refs
+        timelineLayers.scrollLeft += dx
+        this.setState({timelineScrollLeft: timelineLayers.scrollLeft})
     }
 
     private _toggleScaleList = () =>
@@ -182,7 +182,7 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
         const {scale, timelineScrollLeft} = this.state
         const {activeComp, activeClip, currentPreviewFrame, previewPlayed} = this.props.editor
         const {id: compId, framerate} = activeComp ? activeComp : {id: '', framerate: 30}
-        const timelineLanes = activeComp ? Array.from(activeComp.layers) : []
+        const timelineLayers = activeComp ? Array.from(activeComp.layers) : []
 
         const measures = !activeComp ? [] : TimePixelConversion.buildMeasures({
             durationFrames      : activeComp.durationFrames,
@@ -223,7 +223,7 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
                                     </ContextMenu>
                                     {activeComp && (
                                         <SelectList key={compId}>
-                                            {timelineLanes.map(lane => (
+                                            {timelineLayers.map(lane => (
                                                 <LaneLabel key={lane.id} layer={lane} onSelect={this._selectLayer} onRemove={this._removeLayer} />)
                                             )}
                                         </SelectList>
@@ -244,13 +244,13 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
                                     onSeeked={this._onSeeked}
                                 />
 
-                                <ul ref='timelineLanes' className='timeline-lane-container' onScroll={this._scrollSync}>
+                                <ul ref='timelineLayers' className='timeline-lane-container' onScroll={this._scrollSync}>
                                     <ContextMenu>
                                         <MenuItem type='separator' />
                                         <MenuItem label={t('contextMenu.addLayer')} onClick={this._addNewLayer} enabled={!!activeComp} />
                                         <MenuItem type='separator' />
                                     </ContextMenu>
-                                    {activeComp && timelineLanes.map(layer => (
+                                    {activeComp && timelineLayers.map(layer => (
                                         <ClipSpace
                                             key={layer.id!}
                                             layer={layer}

--- a/src/frontend/views/TimelineView/TimelaneView.tsx
+++ b/src/frontend/views/TimelineView/TimelaneView.tsx
@@ -105,9 +105,9 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
         })
     }
 
-    private _selectLayer = laneId =>
+    private _selectLayer = layerId =>
     {
-        this.setState({selectedLayerId: laneId})
+        this.setState({selectedLayerId: layerId})
     }
 
     private _addNewLayer = () =>

--- a/src/frontend/views/TimelineView/TimelaneView.tsx
+++ b/src/frontend/views/TimelineView/TimelaneView.tsx
@@ -40,7 +40,7 @@ interface TimelineViewState {
     timelineScrollLeft: number,
     cursorHeight: number,
     scale: number,
-    selectedLaneId: number|null,
+    selectedLayerId: number|null,
 }
 
 const PX_PER_SEC = 30
@@ -71,7 +71,7 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
         timelineScrollLeft: 0,
         cursorHeight: 0,
         scale: 1,
-        selectedLaneId: null,
+        selectedLayerId: null,
     }
 
     public componentDidMount()
@@ -107,7 +107,7 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
 
     private _selectLayer = laneId =>
     {
-        this.setState({selectedLaneId: laneId})
+        this.setState({selectedLayerId: laneId})
     }
 
     private _addNewLayer = () =>

--- a/src/frontend/views/TimelineView/TimelaneView.tsx
+++ b/src/frontend/views/TimelineView/TimelaneView.tsx
@@ -201,7 +201,7 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
                             {/* Layer Panel */}
                             <Pane className='timeline-labels-container'>
                                 <div className='timeline-labels-header'>
-                                    <div className='--col-name'>Lanes</div>
+                                    <div className='--col-name'>Layers</div>
                                     <div className={s.scaleLabel} onClick={this._toggleScaleList}>
                                         <DropDown ref='scaleList' className={s.scaleList} shownInitial={false}>
                                             <li data-value="50" onClick={this._selectScale}>50%</li>

--- a/src/frontend/views/TimelineView/TimelaneView.tsx
+++ b/src/frontend/views/TimelineView/TimelaneView.tsx
@@ -223,8 +223,8 @@ export default class TimelineView extends React.Component<TimelineViewProps, Tim
                                     </ContextMenu>
                                     {activeComp && (
                                         <SelectList key={compId}>
-                                            {timelineLayers.map(lane => (
-                                                <LaneLabel key={lane.id} layer={lane} onSelect={this._selectLayer} onRemove={this._removeLayer} />)
+                                            {timelineLayers.map(layer => (
+                                                <LaneLabel key={layer.id} layer={layer} onSelect={this._selectLayer} onRemove={this._removeLayer} />)
                                             )}
                                         </SelectList>
                                     )}


### PR DESCRIPTION
Replaced displayed statement `Lanes` with `Layers` according to current term usages.

Class names and module names are not replaced in this change.